### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Rquefts
 This is a R package that implements the QUEFTS (Quantitative Evaluation of the Native Fertility of Tropical Soils) model
 
+Requirement:
+```devtools```
+
 You can install it with:
-
-`devtools::install_github(cropmodels/meteor
-
-`devtools::install_github(cropmodels/Rquefts)`
-
+```
+devtools::install_github("cropmodels/meteor")
+devtools::install_github("cropmodels/Rquefts")
+```
 Note that if you are on windows, you must have [Rtools](https://cran.r-project.org/bin/windows/Rtools/) installed, or install it first to be able to compile and install this package. 


### PR DESCRIPTION
Typos in install instructions, mentioning that you need devtools to run the commands. Should we also list the other package dependencies that devtools usually installs automatically like Rcpp?